### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Lingua/EN/Numbers/Ordinal.pm6
+++ b/lib/Lingua/EN/Numbers/Ordinal.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-module Lingua::EN::Numbers::Ordinal;
+unit module Lingua::EN::Numbers::Ordinal;
 
 sub ordinal(Int $input) is export {
     ##STEP 0: Preparation


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.